### PR TITLE
Add range-specified IP generator

### DIFF
--- a/pkg/random/random.go
+++ b/pkg/random/random.go
@@ -13,6 +13,19 @@ func IPv4() net.IP {
 	return net.IPv4(byte(u32&0xff), byte((u32>>8)&0xff), byte((u32>>16)&0xff), byte((u32>>24)&0xff))
 }
 
+// IPIn returns a random net.IP from the address spaces specified
+// in the provided CIDR addresses ranges. The ranges may be IPv4 or IPv6.
+func IPIn(ranges ...string) (net.IP, error) {
+	ip, ipnet, err := net.ParseCIDR(ranges[rand.Intn(len(ranges))])
+	if err != nil {
+		return nil, err
+	}
+	for i, m := range ipnet.Mask {
+		ip[i] = byte(rand.Intn(255))&^m | ipnet.IP.Mask(ipnet.Mask)[i]
+	}
+	return ip[:len(ipnet.Mask)], nil
+}
+
 // Port returns a random integer from 0 to 65535.
 func Port() int {
 	return rand.Intn(65536)


### PR DESCRIPTION
This allows generation of geolocated IPs for example with

```
func randomIPv4() net.IP {
	ip, err := random.IPIn(
		"1.128.0.0/11",
		"175.16.199.0/24",
		"216.160.83.56/29",
		"81.2.69.142/31",
		"81.2.69.144/31",
		"81.2.69.192/28",
		"89.160.20.112/28",
		"89.160.20.128/25",
		"67.43.156.0/24",
		"2a02:cf40::/29",
	)
	if err != nil {
		panic(err)
	}
	return ip
}
```

making dashboard creation and testing easier.

Please take a look.