### PR TITLE
Add zero padding to random number in the S3 object key

### DIFF
--- a/pkg/output/s3/s3.go
+++ b/pkg/output/s3/s3.go
@@ -72,7 +72,7 @@ func New(cfg *ucfg.Config) (s output.Output, err error) {
 	})
 	var buf bytes.Buffer
 	gw := gzip.NewWriter(&buf)
-	key := fmt.Sprintf("%s_%19d_%3d.gz", c.Prefix, time.Now().UnixNano(), rand.Intn(1000))
+	key := fmt.Sprintf("%s_%19d_%03d.gz", c.Prefix, time.Now().UnixNano(), rand.Intn(1000))
 
 	s = &S3Output{
 		delimiter: c.Delimiter,


### PR DESCRIPTION
The random number added to filenames ranges on [0, 1000). When the value is less that 100 then filenames contain spaces. This adds zero padding for that case.